### PR TITLE
fix: add file cleanup in FileStorage doc test

### DIFF
--- a/cosmoflow/src/storage/backends/file.rs
+++ b/cosmoflow/src/storage/backends/file.rs
@@ -97,6 +97,7 @@ use thiserror::Error;
 /// if let Some(step) = current_step {
 ///     println!("Resuming workflow from step {}", step);
 /// }
+/// # std::fs::remove_file("workflow_state.json").ok();
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///


### PR DESCRIPTION
fix #9 

Add missing std::fs::remove_file() call in workflow integration doc test