### PR TITLE
feat: add terminal action warning system in FlowBuilder

### DIFF
--- a/cosmoflow/src/flow/mod.rs
+++ b/cosmoflow/src/flow/mod.rs
@@ -288,9 +288,22 @@ impl<S: StorageBackend + 'static> FlowBuilder<S> {
         to: impl Into<String>,
     ) -> Self {
         let from_id = from.into();
+        let action_str = action.into();
+        let to_id = to.into();
+
+        // Check if the action is a terminal action and warn the user
+        if self.config.terminal_actions.contains(&action_str) {
+            eprintln!(
+                "⚠️  WARNING: Route from '{}' uses terminal action '{}' which will terminate the workflow immediately.\n\
+                 💡 The target node '{}' will never be reached because '{}' is configured as a terminal action.\n\
+                 🔧 Consider using a different action name to avoid this issue.",
+                from_id, action_str, to_id, action_str
+            );
+        }
+
         let route = Route {
-            action: action.into(),
-            target_node_id: to.into(),
+            action: action_str,
+            target_node_id: to_id,
             condition: None,
         };
 
@@ -307,9 +320,22 @@ impl<S: StorageBackend + 'static> FlowBuilder<S> {
         condition: RouteCondition,
     ) -> Self {
         let from_id = from.into();
+        let action_str = action.into();
+        let to_id = to.into();
+
+        // Check if the action is a terminal action and warn the user
+        if self.config.terminal_actions.contains(&action_str) {
+            eprintln!(
+                "⚠️  WARNING: Conditional route from '{}' uses terminal action '{}' which will terminate the workflow immediately.\n\
+                 💡 The target node '{}' will never be reached because '{}' is configured as a terminal action.\n\
+                 🔧 Consider using a different action name to avoid this issue.",
+                from_id, action_str, to_id, action_str
+            );
+        }
+
         let route = Route {
-            action: action.into(),
-            target_node_id: to.into(),
+            action: action_str,
+            target_node_id: to_id,
             condition: Some(condition),
         };
 
@@ -1231,5 +1257,44 @@ mod tests {
         assert!(result.is_ok());
         let result = result.unwrap();
         assert_eq!(result.execution_path, vec!["start", "success"]);
+    }
+
+    #[test]
+    fn test_terminal_action_warning_in_route() {
+        // Test that building a flow with terminal actions in routes doesn't panic
+        // The warning will be printed to stderr during execution
+        let _flow = FlowBuilder::<MemoryStorage>::new()
+            .route("node1", "complete", "node2") // This should trigger a warning
+            .build();
+
+        // This test mainly ensures the code compiles and runs without panic
+        // In a real-world scenario, you might want to capture stderr to verify the warning
+    }
+
+    #[test]
+    fn test_terminal_action_warning_in_conditional_route() {
+        use crate::flow::route::RouteCondition;
+
+        let _flow = FlowBuilder::<MemoryStorage>::new()
+            .conditional_route("node1", "end", "node2", RouteCondition::Always) // This should trigger a warning
+            .build();
+    }
+
+    #[test]
+    fn test_non_terminal_action_no_warning() {
+        // This should not trigger any warning
+        let _flow = FlowBuilder::<MemoryStorage>::new()
+            .route("node1", "custom_action", "node2")
+            .build();
+    }
+
+    #[test]
+    fn test_multiple_terminal_actions_warnings() {
+        let _flow = FlowBuilder::<MemoryStorage>::new()
+            .route("node1", "complete", "node2") // Warning 1
+            .route("node2", "finish", "node3") // Warning 2
+            .route("node3", "end", "node4") // Warning 3
+            .route("node4", "custom", "node5") // No warning
+            .build();
     }
 }


### PR DESCRIPTION
- Add warning mechanism to detect terminal actions in routes
- Warn users when routes use terminal actions that make target nodes unreachable
- Support both simple routes and conditional routes

Terminal actions ('end', 'complete', 'finish') now trigger warnings when used in routes, helping developers avoid unreachable node configurations.