### PR TITLE
refactor: replace hidden terminal actions with explicit terminal routes

### DIFF
--- a/cosmoflow/src/builtin/llm.rs
+++ b/cosmoflow/src/builtin/llm.rs
@@ -949,17 +949,8 @@ impl<S: StorageBackend + Send + Sync> Node<S> for ApiRequestNode {
     async fn exec(
         &mut self,
         prep_result: Self::PrepResult,
-        context: &ExecutionContext,
+        _context: &ExecutionContext,
     ) -> Result<Self::ExecResult, Self::Error> {
-        // Check if this is a retry and log it
-        if context.current_retry > 0 {
-            eprintln!(
-                "ApiRequestNode retry attempt {} for {} messages",
-                context.current_retry,
-                prep_result.len()
-            );
-        }
-
         // Make the actual API request
         self.make_api_request(prep_result).await
     }

--- a/cosmoflow/src/flow/macros.rs
+++ b/cosmoflow/src/flow/macros.rs
@@ -7,6 +7,8 @@
 //! ## Key Features
 //!
 //! - **flow!**: Declarative workflow construction with automatic routing
+//! - **Explicit Terminal Routes**: Support for the new terminal route system
+//! - **Type-Safe Workflow Termination**: No hidden terminal actions
 //!
 //! ## Quick Start
 //!
@@ -14,22 +16,32 @@
 //! use cosmoflow::flow::macros::*;
 //! use cosmoflow::storage::backends::MemoryStorage;
 //!
-//! // Build a workflow
+//! // Build a workflow with explicit termination
 //! let workflow = flow! {
 //!     storage: MemoryStorage,
-//!     "start" => StartNode,
-//!     "end" => EndNode,
+//!     start: "start",
+//!     nodes: {
+//!         "start": StartNode,
+//!         "end": EndNode,
+//!     },
+//!     routes: {
+//!         "start" - "next" => "end",
+//!     },
+//!     terminals: {
+//!         "end" - "complete",
+//!     }
 //! };
 //! ```
 
-/// Declarative workflow construction with automatic routing and type inference.
+/// Declarative workflow construction with explicit terminal routes and type inference.
 ///
 /// This macro provides a clean, declarative syntax for building CosmoFlow workflows.
-/// It automatically handles node registration, routing setup, and storage configuration.
+/// It automatically handles node registration, routing setup, and explicit terminal route
+/// configuration with the new type-safe termination system.
 ///
 /// # Syntax
 ///
-/// ## Structured syntax with custom action routing:
+/// ## Structured syntax with explicit terminal routes:
 /// ```rust,ignore
 /// flow! {
 ///     storage: StorageType,
@@ -37,15 +49,20 @@
 ///     nodes: {
 ///         "node_id" : NodeBackend,
 ///         "other_id" : OtherBackend,
+///         "final_id" : FinalBackend,
 ///     },
 ///     routes: {
 ///         "node_id" - "custom_action" => "other_id",
 ///         "other_id" - "next" => "final_id",
+///     },
+///     terminals: {
+///         "final_id" - "complete",
+///         "other_id" - "error",
 ///     }
 /// }
 /// ```
 ///
-/// ## Structured syntax with default "next" action routing:
+/// ## Structured syntax with conditional terminal routes:
 /// ```rust,ignore
 /// flow! {
 ///     storage: StorageType,
@@ -56,17 +73,10 @@
 ///     },
 ///     routes: {
 ///         "node_id" - "next" => "other_id",
+///     },
+///     terminals: {
+///         "other_id" - "complete",
 ///     }
-/// }
-/// ```
-///
-/// ## Simplified syntax for linear workflows:
-/// ```rust,ignore
-/// flow! {
-///     storage: StorageType,
-///     "start" => StartBackend,
-///     "process" => ProcessBackend,
-///     "end" => EndBackend,
 /// }
 /// ```
 ///
@@ -76,10 +86,12 @@
 /// * `start` - The ID of the starting node (for structured syntax)
 /// * `nodes` - Node definitions in the format: `"id" : Backend`
 /// * `routes` - Route definitions in the format: `"from" - "action" => "to"`
+/// * `terminals` - Terminal route definitions in the format: `"from" - "action"`
 ///
 /// # Features
 ///
-/// - **Flexible Syntax**: Supports both structured and simplified syntax
+/// - **Explicit Terminal Routes**: Full support for the new terminal route system
+/// - **Type-Safe Termination**: No hidden terminal actions; all termination is explicit
 /// - **Custom Actions**: Supports custom action names for routing (e.g., "default", "error", "success")
 /// - **Type Safety**: Compile-time storage type checking
 /// - **Clean Syntax**: Declarative workflow definition
@@ -87,7 +99,7 @@
 ///
 /// # Examples
 ///
-/// ## Simplified Linear Workflow
+/// ## Structured Workflow with Explicit Terminal Routes
 /// ```rust,ignore
 /// use cosmoflow::flow::macros::flow;
 /// use cosmoflow::storage::backends::MemoryStorage;
@@ -96,19 +108,31 @@
 ///
 /// // Define some nodes (using standard Node implementations)
 /// struct StartNode;
+/// struct ProcessNode;
 /// struct EndNode;
 ///
 /// // Node implementations would be defined here...
 ///
-/// // Build the workflow - nodes will be auto-routed in sequence using "next" action
+/// // Build the workflow with explicit termination
 /// let workflow = flow! {
 ///     storage: MemoryStorage,
-///     "start" => StartNode,
-///     "end" => EndNode,
+///     start: "start",
+///     nodes: {
+///         "start": StartNode,
+///         "process": ProcessNode,
+///         "end": EndNode,
+///     },
+///     routes: {
+///         "start" - "next" => "process",
+///         "process" - "next" => "end",
+///     },
+///     terminals: {
+///         "end" - "complete",
+///     }
 /// };
 /// ```
 ///
-/// ## Structured Workflow with Custom Action Routing
+/// ## Workflow with Error Handling and Multiple Terminal Routes
 /// ```rust,ignore
 /// use cosmoflow::flow::macros::flow;
 /// use cosmoflow::storage::backends::MemoryStorage;
@@ -126,46 +150,92 @@
 ///     storage: MemoryStorage,
 ///     start: "input",
 ///     nodes: {
-///         "input" : DataProcessor,
-///         "error" : ErrorHandler,
-///         "success" : SuccessHandler,
+///         "input": DataProcessor,
+///         "error": ErrorHandler,
+///         "success": SuccessHandler,
 ///     },
 ///     routes: {
-///         "input" - "default" => "success",
+///         "input" - "success" => "success",
 ///         "input" - "error" => "error",
+///     },
+///     terminals: {
+///         "success" - "complete",
+///         "error" - "failed",
 ///     }
 /// };
 /// ```
 ///
-/// ## Structured Workflow with Default "next" Action Routing
+/// ## Simple Linear Workflow
 /// ```rust,ignore
 /// use cosmoflow::flow::macros::flow;
 /// use cosmoflow::storage::backends::MemoryStorage;
 /// use cosmoflow::action::Action;
 /// use cosmoflow::node::Node;
 ///
-/// // Custom node with complex logic
-/// struct DataProcessor;
-/// struct EndNode;
+/// // Simple workflow with linear progression
+/// struct ProcessingNode;
+/// struct FinalNode;
 ///
 /// // Node implementations would be defined here...
 ///
 /// let workflow = flow! {
 ///     storage: MemoryStorage,
-///     start: "input",
+///     start: "process",
 ///     nodes: {
-///         "input" : DataProcessor,
-///         "output" : EndNode,
+///         "process": ProcessingNode,
+///         "final": FinalNode,
 ///     },
 ///     routes: {
-///         "input" - "next" => "output",
+///         "process" - "next" => "final",
+///     },
+///     terminals: {
+///         "final" - "complete",
 ///     }
 /// };
 /// ```
 #[macro_export]
 macro_rules! flow {
-    // Structured syntax with explicit start, nodes, and routes using custom actions
-    // Syntax: "from" : "action" => "to" (using literal tokens)
+    // Structured syntax with explicit start, nodes, routes, and terminal routes
+    (
+        storage: $storage:ty,
+        start: $start:expr,
+        nodes: {
+            $(
+                $id:literal : $backend:expr
+            ),* $(,)?
+        },
+        routes: {
+            $(
+                $from:literal - $action:literal => $to:literal
+            ),* $(,)?
+        },
+        terminals: {
+            $(
+                $term_from:literal - $term_action:literal
+            ),* $(,)?
+        } $(,)?
+    ) => {
+        {
+            let mut builder = $crate::flow::FlowBuilder::<$storage>::new()
+                .start_node($start);
+
+            $(
+                builder = builder.node($id, $backend);
+            )*
+
+            $(
+                builder = builder.route($from, $action, $to);
+            )*
+
+            $(
+                builder = builder.terminal_route($term_from, $term_action);
+            )*
+
+            builder.build()
+        }
+    };
+
+    // Structured syntax with only routes (no terminal routes - for backward compatibility)
     (
         storage: $storage:ty,
         start: $start:expr,
@@ -360,17 +430,42 @@ mod tests {
         }
     }
 
-    // Test 8b: Structured syntax with colon syntax for action routing (literal version)
+    // Test: Structured syntax with explicit terminal routes
     #[test]
-    fn test_flow_macro_colon_action_routing() {
+    fn test_flow_macro_with_terminal_routes() {
         let _workflow = flow! {
             storage: MemoryStorage,
             start: "entry",
             nodes: {
-                "entry" : TestCustomNode::new("default"),
-                "process" : TestCustomNode::new("success"),
-                "error" : TestEndNode,
-                "success" : TestEndNode,
+                "entry": TestCustomNode::new("default"),
+                "process": TestCustomNode::new("success"),
+                "error": TestEndNode,
+                "success": TestEndNode,
+            },
+            routes: {
+                "entry" - "default" => "process",
+                "process" - "success" => "success",
+                "entry" - "error" => "error",
+            },
+            terminals: {
+                "success" - "complete",
+                "error" - "failed",
+            }
+        };
+        // Test new terminal routes syntax
+    }
+
+    // Test: Legacy syntax without terminal routes (backward compatibility)
+    #[test]
+    fn test_flow_macro_legacy_syntax() {
+        let _workflow = flow! {
+            storage: MemoryStorage,
+            start: "entry",
+            nodes: {
+                "entry": TestCustomNode::new("default"),
+                "process": TestCustomNode::new("success"),
+                "error": TestEndNode,
+                "success": TestEndNode,
             },
             routes: {
                 "entry" - "default" => "process",
@@ -378,12 +473,45 @@ mod tests {
                 "entry" - "error" => "error",
             }
         };
-        // Test colon syntax with literal tokens
+        // Test legacy syntax for backward compatibility
     }
 
-    // Test 13a: Colon syntax execution test
+    // Test: New macro with terminal routes execution
     #[tokio::test]
-    async fn test_flow_macro_colon_syntax_execution() {
+    async fn test_flow_macro_with_terminal_routes_execution() {
+        let mut workflow = flow! {
+            storage: MemoryStorage,
+            start: "entry",
+            nodes: {
+                "entry": TestCustomNode::new("default"),
+                "process": TestCustomNode::new("continue"),
+                "end": TestEndNode,
+            },
+            routes: {
+                "entry" - "default" => "process",
+                "process" - "continue" => "end",
+            },
+            terminals: {
+                "end" - "complete",
+            }
+        };
+
+        let mut store = SharedStore::with_storage(MemoryStorage::new());
+        let result = workflow.execute(&mut store).await;
+
+        assert!(result.is_ok(), "Flow macro execution should succeed");
+        let execution_result = result.unwrap();
+        assert!(execution_result.success);
+        assert_eq!(execution_result.steps_executed, 3);
+        assert_eq!(
+            execution_result.execution_path,
+            vec!["entry", "process", "end"]
+        );
+    }
+
+    // Test: Legacy execution test (updated to use explicit terminal routes)
+    #[tokio::test]
+    async fn test_flow_macro_legacy_execution() {
         let mut workflow = FlowBuilder::new()
             .start_node("entry")
             .node("entry", TestCustomNode::new("default"))
@@ -397,16 +525,49 @@ mod tests {
         let mut store = SharedStore::with_storage(MemoryStorage::new());
         let result = workflow.execute(&mut store).await;
 
-        if let Err(e) = &result {
-            eprintln!("Flow macro test failed: {:?}", e);
-        }
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "Legacy flow execution should succeed");
         let execution_result = result.unwrap();
         assert!(execution_result.success);
         assert_eq!(execution_result.steps_executed, 3);
         assert_eq!(
             execution_result.execution_path,
             vec!["entry", "process", "end"]
+        );
+    }
+
+    // Test: Multiple terminal routes
+    #[tokio::test]
+    async fn test_flow_macro_multiple_terminal_routes() {
+        let mut success_workflow = flow! {
+            storage: MemoryStorage,
+            start: "check",
+            nodes: {
+                "check": TestCustomNode::new("success"),
+                "success_handler": TestEndNode,
+                "error_handler": TestEndNode,
+            },
+            routes: {
+                "check" - "success" => "success_handler",
+                "check" - "error" => "error_handler",
+            },
+            terminals: {
+                "success_handler" - "complete",
+                "error_handler" - "failed",
+            }
+        };
+
+        let mut store = SharedStore::with_storage(MemoryStorage::new());
+        let result = success_workflow.execute(&mut store).await;
+
+        assert!(
+            result.is_ok(),
+            "Multiple terminal routes workflow should succeed"
+        );
+        let execution_result = result.unwrap();
+        assert!(execution_result.success);
+        assert_eq!(
+            execution_result.execution_path,
+            vec!["check", "success_handler"]
         );
     }
 }

--- a/cosmoflow/src/flow/mod.rs
+++ b/cosmoflow/src/flow/mod.rs
@@ -199,8 +199,6 @@ pub struct FlowConfig {
     pub detect_cycles: bool,
     /// Starting node ID
     pub start_node_id: String,
-    /// Actions that terminate the flow
-    pub terminal_actions: Vec<String>,
 }
 
 impl Default for FlowConfig {
@@ -209,11 +207,6 @@ impl Default for FlowConfig {
             max_steps: 1000,
             detect_cycles: true,
             start_node_id: "start".to_string(),
-            terminal_actions: vec![
-                "end".to_string(),
-                "complete".to_string(),
-                "finish".to_string(),
-            ],
         }
     }
 }
@@ -285,12 +278,6 @@ impl<S: StorageBackend + 'static> FlowBuilder<S> {
         self
     }
 
-    /// Add a terminal action
-    pub fn terminal_action(mut self, action: impl Into<String>) -> Self {
-        self.config.terminal_actions.push(action.into());
-        self
-    }
-
     /// Add a node to the flow
     pub fn node<T>(mut self, id: impl Into<String>, node: T) -> Self
     where
@@ -321,18 +308,9 @@ impl<S: StorageBackend + 'static> FlowBuilder<S> {
         let action_str = action.into();
         let to_id = to.into();
 
-        // Check if the action is a terminal action and warn the user
-        if self.config.terminal_actions.contains(&action_str) {
-            eprintln!(
-                "⚠️  WARNING: Route from '{from_id}' uses terminal action '{action_str}' which will terminate the workflow immediately.\n\
-                 💡 The target node '{to_id}' will never be reached because '{action_str}' is configured as a terminal action.\n\
-                 🔧 Consider using a different action name to avoid this issue."
-            );
-        }
-
         let route = Route {
             action: action_str,
-            target_node_id: to_id,
+            target_node_id: Some(to_id),
             condition: None,
         };
 
@@ -352,18 +330,79 @@ impl<S: StorageBackend + 'static> FlowBuilder<S> {
         let action_str = action.into();
         let to_id = to.into();
 
-        // Check if the action is a terminal action and warn the user
-        if self.config.terminal_actions.contains(&action_str) {
-            eprintln!(
-                "⚠️  WARNING: Conditional route from '{from_id}' uses terminal action '{action_str}' which will terminate the workflow immediately.\n\
-                 💡 The target node '{to_id}' will never be reached because '{action_str}' is configured as a terminal action.\n\
-                 🔧 Consider using a different action name to avoid this issue."
-            );
-        }
+        let route = Route {
+            action: action_str,
+            target_node_id: Some(to_id),
+            condition: Some(condition),
+        };
+
+        self.routes.entry(from_id).or_default().push(route);
+        self
+    }
+
+    /// Add an explicit terminal route that does not target any node
+    ///
+    /// This is a convenience method for routes that should terminate the workflow
+    /// without routing to another node. It's semantically clearer than using a
+    /// regular route with a terminal action.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "storage-memory")]
+    /// # {
+    /// use cosmoflow::flow::FlowBuilder;
+    /// use cosmoflow::storage::MemoryStorage;
+    ///
+    /// let flow = FlowBuilder::<MemoryStorage>::new()
+    ///     .route("node1", "continue", "node2")
+    ///     .terminal_route("node2", "complete")  // Explicit termination
+    ///     .build();
+    /// # }
+    /// ```
+    pub fn terminal_route(mut self, from: impl Into<String>, action: impl Into<String>) -> Self {
+        let from_id = from.into();
+        let action_str = action.into();
 
         let route = Route {
             action: action_str,
-            target_node_id: to_id,
+            target_node_id: None, // None indicates termination
+            condition: None,
+        };
+
+        self.routes.entry(from_id).or_default().push(route);
+        self
+    }
+
+    /// Add an explicit conditional terminal route
+    ///
+    /// Like `terminal_route`, but only triggers termination if the condition is met.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "storage-memory")]
+    /// # {
+    /// use cosmoflow::flow::{FlowBuilder, route::RouteCondition};
+    /// use cosmoflow::storage::MemoryStorage;
+    ///
+    /// let flow = FlowBuilder::<MemoryStorage>::new()
+    ///     .conditional_terminal_route("node1", "finish", RouteCondition::KeyExists("success".to_string()))
+    ///     .build();
+    /// # }
+    /// ```
+    pub fn conditional_terminal_route(
+        mut self,
+        from: impl Into<String>,
+        action: impl Into<String>,
+        condition: RouteCondition,
+    ) -> Self {
+        let from_id = from.into();
+        let action_str = action.into();
+
+        let route = Route {
+            action: action_str,
+            target_node_id: None, // None indicates termination
             condition: Some(condition),
         };
 
@@ -413,7 +452,6 @@ impl<S: StorageBackend + 'static> FlowBuilder<S> {
 ///     max_steps: 500,
 ///     detect_cycles: true,
 ///     start_node_id: "start".to_string(),
-///     terminal_actions: vec!["complete".to_string(), "error".to_string()],
 /// };
 /// let flow: Flow<MemoryStorage> = Flow::with_config(config);
 /// # }
@@ -476,7 +514,6 @@ impl<S: StorageBackend> Flow<S> {
     ///     max_steps: 1000,
     ///     detect_cycles: true,
     ///     start_node_id: "start".to_string(),
-    ///     terminal_actions: vec!["complete".to_string(), "abort".to_string()],
     /// };
     ///
     /// let flow: Flow<MemoryStorage> = Flow::with_config(config);
@@ -521,11 +558,6 @@ impl<S: StorageBackend> Flow<S> {
     ) -> Result<Option<String>, FlowError> {
         let action_str = action.to_string();
 
-        // Check if this is a terminal action
-        if self.config.terminal_actions.contains(&action_str) {
-            return Ok(None);
-        }
-
         // Get routes for the current node
         let routes = self.routes.get(current_node_id).ok_or_else(|| {
             FlowError::NoRouteFound(current_node_id.to_string(), action_str.clone())
@@ -538,7 +570,7 @@ impl<S: StorageBackend> Flow<S> {
                 if route.condition.as_ref().is_some_and(|c| !c.evaluate(store)) {
                     continue;
                 }
-                return Ok(Some(route.target_node_id.clone()));
+                return Ok(route.target_node_id.clone());
             }
         }
 
@@ -865,7 +897,6 @@ where
     ///     max_steps: 1000,
     ///     detect_cycles: true,
     ///     start_node_id: "entry_point".to_string(),
-    ///     terminal_actions: vec!["complete".to_string()],
     /// };
     /// flow.set_config(new_config);
     /// # }
@@ -931,11 +962,14 @@ where
             }
 
             for route in routes {
-                if !self.nodes.contains_key(&route.target_node_id) {
-                    return Err(FlowError::InvalidConfiguration(format!(
-                        "Target node '{}' in route not found",
-                        route.target_node_id
-                    )));
+                // Only validate target node existence if it's not a terminal route
+                if let Some(target_node_id) = &route.target_node_id {
+                    if !self.nodes.contains_key(target_node_id) {
+                        return Err(FlowError::InvalidConfiguration(format!(
+                            "Target node '{}' in route not found",
+                            target_node_id
+                        )));
+                    }
                 }
             }
         }
@@ -1243,16 +1277,10 @@ mod tests {
         let flow: Flow<MemoryStorage> = FlowBuilder::new()
             .start_node("custom_start")
             .max_steps(500)
-            .terminal_action("custom_end")
             .build();
 
         assert_eq!(flow.config().start_node_id, "custom_start");
         assert_eq!(flow.config().max_steps, 500);
-        assert!(
-            flow.config()
-                .terminal_actions
-                .contains(&"custom_end".to_string())
-        );
     }
 
     #[test]
@@ -1261,7 +1289,6 @@ mod tests {
         assert_eq!(config.start_node_id, "start");
         assert_eq!(config.max_steps, 1000);
         assert!(config.detect_cycles);
-        assert!(config.terminal_actions.contains(&"end".to_string()));
     }
 
     #[tokio::test]
@@ -1310,16 +1337,6 @@ mod tests {
         // This should not trigger any warning
         let _flow = FlowBuilder::<MemoryStorage>::new()
             .route("node1", "custom_action", "node2")
-            .build();
-    }
-
-    #[test]
-    fn test_multiple_terminal_actions_warnings() {
-        let _flow = FlowBuilder::<MemoryStorage>::new()
-            .route("node1", "complete", "node2") // Warning 1
-            .route("node2", "finish", "node3") // Warning 2
-            .route("node3", "end", "node4") // Warning 3
-            .route("node4", "custom", "node5") // No warning
             .build();
     }
 }

--- a/cosmoflow/src/flow/route.rs
+++ b/cosmoflow/src/flow/route.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 pub struct Route {
     /// The action that triggers this route
     pub action: String,
-    /// The target node ID
-    pub target_node_id: String,
+    /// The target node ID, or None for terminal routes
+    pub target_node_id: Option<String>,
     /// Optional condition that must be met for this route to be taken
     pub condition: Option<RouteCondition>,
 }

--- a/examples/custom_node.rs
+++ b/examples/custom_node.rs
@@ -587,7 +587,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("secondary_counter", "max_reached", "coordinator")
         // Analysis flow
         .route("statistics", "report", "report")
-        .terminal_route("report", "complete")  // Explicit termination
+        .terminal_route("report", "complete") // Explicit termination
         .build();
 
     // Disable cycle detection to allow iterative workflows

--- a/examples/custom_node.rs
+++ b/examples/custom_node.rs
@@ -587,7 +587,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("secondary_counter", "max_reached", "coordinator")
         // Analysis flow
         .route("statistics", "report", "report")
-        .terminal_action("complete")
+        .terminal_route("report", "complete")  // Explicit termination
         .build();
 
     // Disable cycle detection to allow iterative workflows

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -246,7 +246,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .node("hello", HelloNode::new("Hello from CosmoFlow minimal!"))
         .node("response", ResponseNode)
         .route("hello", "next", "response")
-        .terminal_route("response", "complete")  // Explicit termination
+        .terminal_route("response", "complete") // Explicit termination
         .build();
 
     println!("📋 Flow configuration:");

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -246,13 +246,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .node("hello", HelloNode::new("Hello from CosmoFlow minimal!"))
         .node("response", ResponseNode)
         .route("hello", "next", "response")
-        .terminal_action("complete")
+        .terminal_route("response", "complete")  // Explicit termination
         .build();
 
     println!("📋 Flow configuration:");
     println!("  Start node: {}", flow.config().start_node_id);
     println!("  Max steps: {}", flow.config().max_steps);
-    println!("  Terminal actions: {:?}", flow.config().terminal_actions);
     println!();
 
     // Validate the flow

--- a/examples/unified_counter.rs
+++ b/examples/unified_counter.rs
@@ -299,7 +299,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("hello", "next", "counter1") // Unused route (legacy)
         .route("counter1", "continue", "counter2") // 3 → counter2
         .route("counter2", "continue", "counter3") // 6 → counter3
-        .terminal_action("complete") // 11 → terminate
+        .terminal_route("counter3", "complete") // 11 → terminate (explicit)
         .max_steps(20) // Safety limit
         .build();
 

--- a/examples/unified_hello_world.rs
+++ b/examples/unified_hello_world.rs
@@ -311,12 +311,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build the workflow using the new unified API
     // - start_with() creates the starting node and sets it as the entry point
-    // - route() defines transitions between nodes (unused here since we terminate)
-    // - terminal_action() marks "complete" as a workflow-ending action
+    // - terminal_route() defines explicit workflow termination
     let mut flow = FlowBuilder::new()
         .start_with("hello", HelloNode::new("CosmoFlow with Unified Node!"))
-        .route("hello", "complete", "") // Route to nowhere (terminal action)
-        .terminal_action("complete") // Mark "complete" as terminal
+        .terminal_route("hello", "complete") // Explicit termination
         .build();
 
     println!("\n📋 Executing workflow...");


### PR DESCRIPTION
## Overview

This PR fundamentally redesigns CosmoFlow's workflow termination system, eliminating hidden string-based terminal actions in favor of explicit, type-safe terminal routes. This change makes workflow termination points clear, debuggable, and predictable.

## Breaking Changes

### Old (Hidden Terminal Actions)
```rust
let flow = FlowBuilder::new()
    .terminal_action("complete")  // Hidden configuration
    .route("node1", "complete", "node2")  // ⚠️ node2 never reached!
    .build();
```

### New (Explicit Terminal Routes)
```rust
let flow = FlowBuilder::new()
    .route("node1", "continue", "node2")
    .terminal_route("node2", "complete")  // ✅ Explicit termination
    .build();
```

## 🚀 Key Changes

### 1. **Explicit Terminal Routes**
- **Added**: `.terminal_route(from, action)` - explicit workflow termination
- **Added**: `.conditional_terminal_route(from, action, condition)` - conditional termination
- **Removed**: `.terminal_action(action)` - hidden configuration method
- **Removed**: `terminal_actions` field from `FlowConfig`

### 2. **Type-Safe Route Structure**
```rust
pub struct Route {
    pub action: String,
    pub target_node_id: Option<String>,  // None = terminal route
    pub condition: Option<RouteCondition>,
}
```

### 3. **Silent Framework Operation**
- **Removed**: All `eprintln!` and framework-level logging
- **Removed**: Warning messages about terminal action conflicts
- **Result**: Framework is now completely silent; all output is application-controlled

## 📋 Updated Examples

All examples have been updated to use the new explicit termination API:

### Hello World Example
```diff
- .terminal_action("complete")
+ .terminal_route("response", "complete")
```

### Custom Node Example
```diff
- .terminal_action("complete")
+ .terminal_route("report", "complete")
```

### Unified Examples
```diff
- .terminal_action("complete")
+ .terminal_route("hello", "complete")
```